### PR TITLE
chore: modernize to Java 21 idioms and upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ mvn clean package -DskipTests  # Skip tests
 - Custom `ConstraintValidator` for domain validation
 - JaCoCo for coverage reporting
 
+### Java 21 Features
+
+| Feature | Where |
+|---------|-------|
+| `instanceof` pattern matching | `equals()` in User, Role, Authority |
+| Sealed classes | `BusinessException sealed permits ResourceNotFoundException, EmailAlreadyExistsException` |
+| Switch pattern matching | `RestExceptionHandler` — single handler dispatches by sealed subtype |
+| `List.of()` / `.toList()` | Config, JwtConfig, RestExceptionHandler, TokenAuthenticationService |
+| `List.getFirst()` | Sequenced Collections API in tests |
+| Optional chain | `UserLogged` — `Optional.ofNullable().filter().map().flatMap().orElse()` |
+
 ## Troubleshooting
 
 ### H2 Console Access (dev profile only)
@@ -310,6 +321,19 @@ The collection auto-saves `token` and `roleId` via test scripts.
 This project is licensed under the GPL-3.0 License — see the [LICENSE.md](LICENSE.md) file for details.
 
 ## Changelog
+
+### v5 — Java 21 Modernization
+
+- `instanceof` pattern matching in `equals()` — User, Role, Authority
+- Sealed exception hierarchy: `BusinessException sealed permits ResourceNotFoundException, EmailAlreadyExistsException`
+- Switch pattern matching in `RestExceptionHandler` — 3 `@ExceptionHandler` methods merged into 1 with `switch (exception) { case ... }`
+- `Arrays.asList()` → `List.of()` in Config.java (immutable, no null elements)
+- `Collectors.toList()` → `.toList()` in JwtConfig, RestExceptionHandler
+- `Collectors.joining()` → `String.join()` in TokenAuthenticationService
+- Optional chain in `UserLogged` — replaced if/null/try-catch with `Optional.ofNullable().filter().map().flatMap().orElse()`
+- `List.get(0)` → `List.getFirst()` (Sequenced Collections API) in tests
+- Removed unused `Collectors` imports
+- 92 tests, 0 failures
 
 ### v4 — Architecture Improvements
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <spring-cloud.version>2024.0.1</spring-cloud.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-contract-maven-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>4.3.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <baseClassForTests>com.sergiovitorino.springbootjwt.contract.BaseContractTest</baseClassForTests>

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/BusinessException.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/BusinessException.java
@@ -1,6 +1,7 @@
 package com.sergiovitorino.springbootjwt.domain.exception;
 
-public class BusinessException extends RuntimeException {
+public sealed class BusinessException extends RuntimeException
+        permits ResourceNotFoundException, EmailAlreadyExistsException {
     public BusinessException(String message) {
         super(message);
     }

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/EmailAlreadyExistsException.java
@@ -1,6 +1,6 @@
 package com.sergiovitorino.springbootjwt.domain.exception;
 
-public class EmailAlreadyExistsException extends BusinessException {
+public final class EmailAlreadyExistsException extends BusinessException {
     public EmailAlreadyExistsException(String message) {
         super(message);
     }

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/exception/ResourceNotFoundException.java
@@ -1,6 +1,6 @@
 package com.sergiovitorino.springbootjwt.domain.exception;
 
-public class ResourceNotFoundException extends BusinessException {
+public final class ResourceNotFoundException extends BusinessException {
     public ResourceNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/model/Authority.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/model/Authority.java
@@ -65,8 +65,7 @@ public class Authority {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Authority authority = (Authority) o;
+        if (!(o instanceof Authority authority)) return false;
         return java.util.Objects.equals(id, authority.id);
     }
 

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/model/Role.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/model/Role.java
@@ -86,8 +86,7 @@ public class Role {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Role role = (Role) o;
+        if (!(o instanceof Role role)) return false;
         return Objects.equals(id, role.id);
     }
 

--- a/src/main/java/com/sergiovitorino/springbootjwt/domain/model/User.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/domain/model/User.java
@@ -152,8 +152,7 @@ public class User extends AbstractEntity implements UserDetails {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        User user = (User) o;
+        if (!(o instanceof User user)) return false;
         return Objects.equals(id, user.id);
     }
 

--- a/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/Config.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/Config.java
@@ -9,7 +9,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
+import java.util.List;
 
 import static org.springframework.http.HttpHeaders.*;
 
@@ -22,8 +22,8 @@ public class Config {
     @Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+		configuration.setAllowedOrigins(List.of(allowedOrigins.split(",")));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		configuration.addExposedHeader(AUTHORIZATION);
 		configuration.addAllowedHeader(AUTHORIZATION);
 		configuration.addAllowedHeader(ACCESS_CONTROL_ALLOW_ORIGIN);

--- a/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/JwtConfig.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/JwtConfig.java
@@ -19,7 +19,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Collectors;
+
 
 @Configuration
 public class JwtConfig {
@@ -64,8 +64,8 @@ public class JwtConfig {
             return Arrays.stream(authoritiesClaim.split(","))
                     .map(String::trim)
                     .filter(s -> !s.isEmpty())
-                    .map(SimpleGrantedAuthority::new)
-                    .collect(Collectors.toList());
+                    .<org.springframework.security.core.GrantedAuthority>map(SimpleGrantedAuthority::new)
+                    .toList();
         });
         return converter;
     }

--- a/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/TokenAuthenticationService.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/TokenAuthenticationService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class TokenAuthenticationService {
@@ -51,8 +50,6 @@ public class TokenAuthenticationService {
     }
 
     private String extractAuthorities(final List<Authority> authorities) {
-        return authorities.stream()
-                .map(Authority::getName)
-                .collect(Collectors.joining(","));
+        return String.join(",", authorities.stream().map(Authority::getName).toList());
     }
 }

--- a/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/UserLogged.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/infrastructure/security/UserLogged.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Component
@@ -12,16 +13,18 @@ import java.util.UUID;
 public class UserLogged {
 
     public UUID getUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            try {
-                return UUID.fromString(authentication.getName());
-            } catch (IllegalArgumentException e) {
-                // Logar erro ou retornar nulo/padrão se o principal não for um UUID válido
-                return null;
-            }
-        }
-        return null;
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getName)
+                .flatMap(this::parseUuid)
+                .orElse(null);
     }
 
+    private Optional<UUID> parseUuid(String value) {
+        try {
+            return Optional.of(UUID.fromString(value));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/com/sergiovitorino/springbootjwt/ui/rest/controller/RestExceptionHandler.java
+++ b/src/main/java/com/sergiovitorino/springbootjwt/ui/rest/controller/RestExceptionHandler.java
@@ -15,9 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class RestExceptionHandler {
@@ -30,56 +28,49 @@ public class RestExceptionHandler {
         this.mapper = mapper;
     }
 
-    @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<String> handleResourceNotFound(ResourceNotFoundException exception) throws Exception {
-        return buildErrorResponse(HttpStatus.NOT_FOUND, "NOT_FOUND", exception);
-    }
-
-    @ExceptionHandler(EmailAlreadyExistsException.class)
-    public ResponseEntity<String> handleEmailAlreadyExists(EmailAlreadyExistsException exception) throws Exception {
-        return buildErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY, "EMAIL_ALREADY_EXISTS", exception);
-    }
-
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<String> handleBusinessException(BusinessException exception) throws Exception {
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, "BUSINESS_ERROR", exception);
+        var result = switch (exception) {
+            case ResourceNotFoundException e -> new ErrorResult(HttpStatus.NOT_FOUND, "NOT_FOUND", e.getMessage());
+            case EmailAlreadyExistsException e -> new ErrorResult(HttpStatus.UNPROCESSABLE_ENTITY, "EMAIL_ALREADY_EXISTS", e.getMessage());
+            default -> new ErrorResult(HttpStatus.BAD_REQUEST, "BUSINESS_ERROR", exception.getMessage());
+        };
+        return buildErrorResponse(result.status(), result.errorCode(), result.message());
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<String> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException exception) throws Exception {
         log.warn("Invalid argument type: {}", exception.getMessage());
-        List<ErrorBean> errors = Collections.singletonList(new ErrorBean("INVALID_ARGUMENT", null, "Invalid UUID format"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapper.writeValueAsString(errors));
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "Invalid UUID format");
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) throws Exception {
         List<ErrorBean> errors = exception.getBindingResult().getFieldErrors().stream()
                 .map(fieldError -> new ErrorBean(null, fieldError.getField(), fieldError.getDefaultMessage()))
-                .collect(Collectors.toList());
+                .toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapper.writeValueAsString(errors));
     }
 
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<String> handleHandlerMethodValidation(HandlerMethodValidationException exception) throws Exception {
-        // Para validação de parâmetros de método (não @RequestBody)
         List<ErrorBean> errors = exception.getAllValidationResults().stream()
                 .flatMap(result -> result.getResolvableErrors().stream())
                 .map(error -> new ErrorBean(null, null, error.getDefaultMessage()))
-                .collect(Collectors.toList());
+                .toList();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapper.writeValueAsString(errors));
     }
 
     @ExceptionHandler
     public ResponseEntity<String> exceptionHandler(final Exception exception) throws Exception {
         log.error("Unhandled exception occurred: {}", exception.getMessage(), exception);
-        List<ErrorBean> errors = Collections.singletonList(new ErrorBean("InternalServerError", null, "An unexpected error occurred"));
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(mapper.writeValueAsString(errors));
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "InternalServerError", "An unexpected error occurred");
     }
 
-    private ResponseEntity<String> buildErrorResponse(HttpStatus status, String errorCode, Exception exception) throws Exception {
-        List<ErrorBean> errors = Collections.singletonList(new ErrorBean(errorCode, null, exception.getMessage()));
+    private ResponseEntity<String> buildErrorResponse(HttpStatus status, String errorCode, String message) throws Exception {
+        List<ErrorBean> errors = List.of(new ErrorBean(errorCode, null, message));
         return ResponseEntity.status(status).body(mapper.writeValueAsString(errors));
     }
 
+    private record ErrorResult(HttpStatus status, String errorCode, String message) {}
 }

--- a/src/test/java/com/sergiovitorino/springbootjwt/ui/rest/controller/test/RestExceptionHandlerTest.java
+++ b/src/test/java/com/sergiovitorino/springbootjwt/ui/rest/controller/test/RestExceptionHandlerTest.java
@@ -25,39 +25,38 @@ public class RestExceptionHandlerTest {
     public void testIfExceptionParserIsOk() throws Exception {
         var responseEntity = handler.exceptionHandler(new IllegalArgumentException("Mock Exception"));
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.getStatusCode());
-        // Should NOT leak class name
         assertFalse(responseEntity.getBody().contains("IllegalArgumentException"));
         assertTrue(responseEntity.getBody().contains("InternalServerError"));
     }
 
     @Test
     public void testIfResourceNotFoundReturns404WithErrorCode() throws Exception {
-        var responseEntity = handler.handleResourceNotFound(new ResourceNotFoundException("User not found"));
+        var responseEntity = handler.handleBusinessException(new ResourceNotFoundException("User not found"));
         assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
 
         List<ErrorBean> errors = mapper.readValue(responseEntity.getBody(), mapper.getTypeFactory().constructParametricType(List.class, ErrorBean.class));
-        assertEquals("NOT_FOUND", errors.get(0).errorCode());
-        assertEquals("User not found", errors.get(0).message());
-        // Should NOT contain internal package names
+        assertEquals("NOT_FOUND", errors.getFirst().errorCode());
+        assertEquals("User not found", errors.getFirst().message());
         assertFalse(responseEntity.getBody().contains("com.sergiovitorino"));
     }
 
     @Test
     public void testIfEmailAlreadyExistsReturns422WithErrorCode() throws Exception {
-        var responseEntity = handler.handleEmailAlreadyExists(new EmailAlreadyExistsException("E-mail already"));
+        var responseEntity = handler.handleBusinessException(new EmailAlreadyExistsException("E-mail already"));
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, responseEntity.getStatusCode());
 
         List<ErrorBean> errors = mapper.readValue(responseEntity.getBody(), mapper.getTypeFactory().constructParametricType(List.class, ErrorBean.class));
-        assertEquals("EMAIL_ALREADY_EXISTS", errors.get(0).errorCode());
+        assertEquals("EMAIL_ALREADY_EXISTS", errors.getFirst().errorCode());
     }
 
     @Test
-    public void testIfBusinessExceptionReturns400WithErrorCode() throws Exception {
+    public void testIfBusinessExceptionDefaultReturns400() throws Exception {
+        // Direct BusinessException (not a subclass) hits the default branch
         var responseEntity = handler.handleBusinessException(new BusinessException("Invalid operation"));
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
 
         List<ErrorBean> errors = mapper.readValue(responseEntity.getBody(), mapper.getTypeFactory().constructParametricType(List.class, ErrorBean.class));
-        assertEquals("BUSINESS_ERROR", errors.get(0).errorCode());
+        assertEquals("BUSINESS_ERROR", errors.getFirst().errorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **7 Java 21 features applied** — instanceof pattern matching, sealed classes, switch pattern matching, `List.of()`, `.toList()`, `String.join()`, Optional chain, Sequenced Collections `getFirst()`
- **3 dependency upgrades** — Spring Cloud 2024.0.1 → 2025.0.0, spring-cloud-contract 4.2.0 → 4.3.0, maven-compiler-plugin 3.13.0 → 3.15.0
- **springdoc-openapi 3.0.x rejected** — requires Spring Boot 4.x (bean definition conflict), kept at 2.8.5

## Java 21 Features Applied

| Feature | Where | Before → After |
|---------|-------|----------------|
| `instanceof` pattern matching | User, Role, Authority `.equals()` | `if (o == null \|\| getClass()...) { Foo f = (Foo) o; }` → `if (!(o instanceof Foo f))` |
| Sealed classes | `BusinessException` | `class` → `sealed class permits ...` + `final` subclasses |
| Switch pattern matching | `RestExceptionHandler` | 3 `@ExceptionHandler` → 1 with `switch (e) { case ResourceNotFoundException r -> ... }` |
| `List.of()` | Config.java | `Arrays.asList(...)` → `List.of(...)` |
| `.toList()` | JwtConfig, RestExceptionHandler | `.collect(Collectors.toList())` → `.toList()` |
| `String.join()` | TokenAuthenticationService | `.collect(Collectors.joining(","))` → `String.join(",", ...toList())` |
| Optional chain | UserLogged | if/null/try-catch → `Optional.ofNullable().filter().map().flatMap().orElse()` |
| `getFirst()` | RestExceptionHandlerTest | `.get(0)` → `.getFirst()` (Sequenced Collections API) |

## Dependency Upgrades

| Dependency | Before | After | Notes |
|---|---|---|---|
| Spring Cloud | 2024.0.1 | **2025.0.0** | Aligned with Boot 3.5.x |
| spring-cloud-contract | 4.2.0 | **4.3.0** | Aligned with Cloud 2025.0.0 |
| maven-compiler-plugin | 3.13.0 | **3.15.0** | Latest stable 3.x |
| springdoc-openapi | 2.8.5 | 2.8.5 | 3.0.x incompatible with Boot 3.5.x |

## Test plan
- [x] `mvn clean test` — 92 tests, 0 failures
- [ ] Verify sealed class: add a new `BusinessException` subclass without `permits` → should fail compilation
- [ ] `POST /login` → token issued correctly (TokenAuthenticationService `String.join` change)
- [ ] Trigger 404 → response has `NOT_FOUND` error code (switch pattern matching)
- [ ] Trigger 422 → response has `EMAIL_ALREADY_EXISTS` error code
- [ ] Check no `Collectors` import warnings in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)